### PR TITLE
Fixed dashboard sorting in UI

### DIFF
--- a/ips/services/dashboard.py
+++ b/ips/services/dashboard.py
@@ -47,8 +47,6 @@ def dashboard_view():
                                records=records,
                                form=form)
 
-    records.sort(key=lambda x: x['LAST_MODIFIED'])
-
     # Setup key value pairs for displaying run information
     run_types = {
         '0': 'Test',

--- a/ips/templates/dashboard.html
+++ b/ips/templates/dashboard.html
@@ -60,7 +60,7 @@
                     </p>
                     <div>
                     <!-- for each record, render each data value -->
-                    {% for record in records|reverse %}
+                    {% for record in records %}
                         <hr/>
                         <br>
                         <h3>{{ record['RUN_NAME'] }}</h3>


### PR DESCRIPTION
As results are now sorted correctly in API we have no need for any more sort steps in the UI

- removed reverse step in dashboard template
- removed list sorting in dashboard view